### PR TITLE
Upgraded Android SDK version to 1.0.4 and integrated the changes

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,5 +45,5 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation 'com.google.code.gson:gson:2.9.0'
 
-    implementation "com.dashx:dashx-android:1.0.3"
+    implementation "com.dashx:dashx-android:1.0.4"
 }  

--- a/android/src/main/java/com/dashx/rn/sdk/DashXReactNativeModule.kt
+++ b/android/src/main/java/com/dashx/rn/sdk/DashXReactNativeModule.kt
@@ -31,7 +31,7 @@ class DashXReactNativeModule(private val reactContext: ReactApplicationContext) 
 
     @ReactMethod
     fun configure(options: ReadableMap) {
-        dashXClient = DashX.createInstance(
+        dashXClient = DashX.configure(
             reactContext,
             options.getString("publicKey")!!,
             options.getStringIfPresent("baseURI"),
@@ -187,10 +187,10 @@ class DashXReactNativeModule(private val reactContext: ReactApplicationContext) 
 
     @ReactMethod
     fun saveStoredPreferences(preferenceData: ReadableMap?, promise: Promise) {
-        val preferencesHashMap = MapUtil.toJSONElement(preferenceData)
+        val preferencesString = MapUtil.toJSONElement(preferenceData).toString()
 
         dashXClient?.saveStoredPreferences(
-            preferencesHashMap,
+            preferencesString,
             onError = {
                 promise.reject("EUNSPECIFIED", it)
             },
@@ -220,23 +220,6 @@ class DashXReactNativeModule(private val reactContext: ReactApplicationContext) 
         dashXClient?.uploadExternalAsset(
             fileObject,
             externalColumnId,
-            onError = {
-                promise.reject("EUNSPECIFIED", it)
-            },
-            onSuccess = { content ->
-                val jsonObject = Gson().toJsonTree(content, ExternalAsset::class.java).asJsonObject
-                promise.resolve(convertJsonToMap(jsonObject))
-            }
-        )
-    }
-
-    @ReactMethod
-    fun externalAsset(
-            id: String,
-            promise: Promise
-    ) {
-        dashXClient?.externalAsset(
-            id,
             onError = {
                 promise.reject("EUNSPECIFIED", it)
             },


### PR DESCRIPTION
- Used `configure` method instead of the remove `createInstance`
- Stringified preferences map as required by the Android SDK